### PR TITLE
fix: import puik-theme before tailwindcss to preserve font @imports

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,2 +1,4 @@
-@import "tailwindcss";
+/* puik-theme en premier : ses @import url() de polices (IBM Plex, Material
+   Symbols) doivent précéder toute autre règle CSS (contrainte @import). */
 @import "@prestashopcorp/puik-theme";
+@import "tailwindcss";


### PR DESCRIPTION
Suivi de #33. Correctif d'ordre des `@import` dans `src/style.css`.

`puik-theme/index.css` embarque des `@import url()` vers Google Fonts
(IBM Plex Sans + **Material Symbols Rounded**, la police d'icônes de Puik).
En important `tailwindcss` avant `puik-theme`, ces `@import url()` se
retrouvaient au milieu du CSS généré → invalide (un `@import` doit précéder
toute autre règle) → ignorés par PostCSS, donc icônes/police non chargées.

Inverser l'ordre (`puik-theme` puis `tailwindcss`) garde les `@import` de
polices en tête. Vérifié : plus d'avertissement `@import must precede`, et les
deux polices sont bien présentes dans le CSS de production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)