### PR TITLE
chore: translate French text to English, add CLAUDE.md language convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ dist-ssr
 coverage
 *.local
 
-# Vite dependency pre-bundling cache (généré automatiquement)
+# Vite dependency pre-bundling cache (auto-generated)
 .vite
 
 /cypress/videos/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Project conventions
+
+## Language
+
+All code must be written in **English**: comments, identifiers, commit messages,
+and string literals (including demo/sample content). Do not introduce French
+text into the codebase, even in throwaway test data.
+
+You may converse with the user in French, but anything written to a file stays
+in English.

--- a/src/components/testNotificationBar.vue
+++ b/src/components/testNotificationBar.vue
@@ -10,10 +10,10 @@ import type { PuikMessagesType } from '@prestashopcorp/puik-components';
 const messages: PuikMessagesType = [
     {
         icon: "sentiment_satisfied",
-        text: "Promo thèmes: profitez de -20% sur tous les thèmes PrestaShop",
+        text: "Theme sale: get -20% off all PrestaShop themes",
         link: {
             url: "#",
-            text: "J'en profite",
+            text: "Get the deal",
         },
     },
 ]

--- a/src/components/testSnackbar.vue
+++ b/src/components/testSnackbar.vue
@@ -104,7 +104,7 @@
     const { snackbarsState, removeSnackbar } = useSnackbar(
       {
         title: 'Snackbar 1',
-        description: 'youpi !!!! ça fonctionne !!!!',
+        description: 'yay !!!! it works !!!!',
         hasCloseButton: true,
         variant: 'success',
         onOpenChange: (open) => {
@@ -127,7 +127,7 @@
     const { snackbarsState, removeSnackbar } = useSnackbar(
       {
         title: 'Snackbar 2',
-        description: 'youpi !!!! ça fonctionne !!!!',
+        description: 'yay !!!! it works !!!!',
         hasCloseButton: true,
         variant: 'default',
         onOpenChange: (open) => {
@@ -150,7 +150,7 @@
     const { snackbarsState, removeSnackbar } = useSnackbar(
       {
         title: 'Snackbar 3',
-        description: 'youpi !!!! ça fonctionne !!!!',
+        description: 'yay !!!! it works !!!!',
         hasCloseButton: true,
         variant: 'danger',
         onOpenChange: (open) => {

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
-/* puik-theme en premier : ses @import url() de polices (IBM Plex, Material
-   Symbols) doivent précéder toute autre règle CSS (contrainte @import). */
+/* puik-theme first: its font @import url() statements (IBM Plex, Material
+   Symbols) must precede every other CSS rule (@import ordering constraint). */
 @import "@prestashopcorp/puik-theme";
 @import "tailwindcss";


### PR DESCRIPTION
Translate the remaining French in the codebase to English and document the convention.

- Comments: `.gitignore`, `src/style.css`
- Demo strings: `testSnackbar.vue`, `testNotificationBar.vue`
- Add `CLAUDE.md` requiring all code/comments/strings to be written in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)