### PR TITLE
docs: enrich CLAUDE.md and rewrite README for the Puik test app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,73 @@
-# Project conventions
+# CLAUDE.md
+
+## What this project is
+
+A Vue 3 sandbox app for exercising **Puik**, PrestaShop's UI Kit
+(`@prestashopcorp/puik-*`). It renders Puik components on two routes so they can
+be checked visually:
+
+- `/` → `VueComponentsView` (Vue components, `src/components/test*.vue`)
+- `/web-components` → `WebComponentsView` (web components, `src/web-components/*.vue`)
+
+It is a test harness, not a product — components live as `testXxx.vue` demo files.
+
+## Stack
+
+- **Vue 3.5** + **Vue Router 4** + **Pinia** (entry: `src/main.ts`)
+- **Vite 6** build, **Vitest** unit tests, **TypeScript** (`vue-tsc`)
+- **Tailwind CSS v4** via the `@tailwindcss/vite` plugin
+- **Puik 2.8.1** (`puik-components`, `puik-theme`, `puik-web-components`, `puik-resolver`)
+- **pnpm** is the package manager — always use `pnpm`, never `npm`/`yarn`
+
+## Commands
+
+```sh
+pnpm dev          # Vite dev server (http://localhost:5173)
+pnpm build        # type-check + production build
+pnpm build-only   # vite build alone
+pnpm type-check   # vue-tsc --noEmit
+pnpm test:unit    # vitest
+pnpm lint         # eslint --fix
+pnpm format       # prettier on src/
+```
+
+## How things are wired
+
+- **Puik components auto-import.** `PuikResolver` (in `vite.config.ts`, via
+  `unplugin-vue-components` + `unplugin-auto-import`) imports Puik components and
+  their CSS on demand — do **not** add manual `import { PuikButton } from ...`.
+  Auto-import metadata lives in `components.d.ts` (generated, committed).
+- **Web components** are detected with `isCustomElement: tag => tag.includes('-web')`
+  in the Vue plugin config.
+- **Global styles** come from `src/style.css`, imported in `main.ts`.
+
+## Styling conventions / gotchas
+
+- **Puik 2.8 uses Tailwind v4.** The old `@prestashopcorp/puik-tailwind-preset`
+  and `tailwind.config.js`/`postcss.config.js` are obsolete since Puik 2.6 — do
+  not reintroduce them. Theme tokens ship as compiled CSS in `puik-theme`.
+- **`src/style.css` import order matters.** `@import "@prestashopcorp/puik-theme"`
+  must come **before** `@import "tailwindcss"`, because `puik-theme` emits font
+  `@import url()` statements (IBM Plex, Material Symbols) that must precede every
+  other CSS rule. Reversing the order makes PostCSS drop the icon font.
+- **Known harmless warning:** the production build prints one
+  `Invalid media query` warning from `@media (max-width:var(--screen-xs))` inside
+  `puik-theme@2.8.1`. It is an upstream Puik bug (reported in
+  PrestaShopCorp/puik#527), not ours — do not try to fix it here.
+
+## Repo conventions
+
+- **Package manager:** pnpm. `pnpm.overrides` in `package.json` pins transitive
+  deps for security (e.g. `yaml >=2.8.3`); keep `pnpm audit` clean.
+- **`"type": "module"`** is required (the `@tailwindcss/vite` plugin is ESM-only).
+- **`.vite/` is gitignored** (Vite's dependency cache; it was committed by mistake
+  once — never re-add it).
+- **Git flow:** work on `develop`, open a PR to `main`, then merge. Dependabot
+  scans `main`, so security fixes only clear the alert once merged to `main`.
 
 ## Language
 
 All code must be written in **English**: comments, identifiers, commit messages,
-and string literals (including demo/sample content). Do not introduce French
-text into the codebase, even in throwaway test data.
-
-You may converse with the user in French, but anything written to a file stays
-in English.
+and string literals (including demo/sample content). Do not introduce French text
+into the codebase, even in throwaway test data. You may converse with the user in
+French, but anything written to a file stays in English.

--- a/README.md
+++ b/README.md
@@ -1,52 +1,57 @@
-# vue-test-project
+# puik-vue-app-test
 
-This template should help get you started developing with Vue 3 in Vite.
+A Vue 3 sandbox app for exercising **[Puik](https://uikit.prestashop.com/)**,
+PrestaShop's UI Kit (`@prestashopcorp/puik-*`). It renders Puik components on two
+routes so they can be checked visually:
 
-## Recommended IDE Setup
+- `/` — Vue components (`src/components/test*.vue`)
+- `/web-components` — web components (`src/web-components/*.vue`)
 
-[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur) + [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin).
+This is a test harness, not a product.
 
-## Type Support for `.vue` Imports in TS
+## Stack
 
-TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin) to make the TypeScript language service aware of `.vue` types.
+- Vue 3.5 · Vue Router 4 · Pinia
+- Vite 6 · Vitest · TypeScript (`vue-tsc`)
+- Tailwind CSS **v4** (via `@tailwindcss/vite`)
+- Puik 2.8.1
+- **pnpm** as the package manager
 
-If the standalone TypeScript plugin doesn't feel fast enough to you, Volar has also implemented a [Take Over Mode](https://github.com/johnsoncodehk/volar/discussions/471#discussioncomment-1361669) that is more performant. You can enable it by the following steps:
-
-1. Disable the built-in TypeScript Extension
-    1) Run `Extensions: Show Built-in Extensions` from VSCode's command palette
-    2) Find `TypeScript and JavaScript Language Features`, right click and select `Disable (Workspace)`
-2. Reload the VSCode window by running `Developer: Reload Window` from the command palette.
-
-## Customize configuration
-
-See [Vite Configuration Reference](https://vitejs.dev/config/).
-
-## Project Setup
+## Getting started
 
 ```sh
-npm install
+pnpm install
+pnpm dev          # dev server on http://localhost:5173
 ```
 
-### Compile and Hot-Reload for Development
+## Scripts
 
 ```sh
-npm run dev
+pnpm dev          # Vite dev server
+pnpm build        # type-check + production build
+pnpm preview      # preview the production build
+pnpm test:unit    # run Vitest unit tests
+pnpm lint         # ESLint (--fix)
+pnpm format       # Prettier on src/
 ```
 
-### Type-Check, Compile and Minify for Production
+## Notes
 
-```sh
-npm run build
-```
+- **Puik components are auto-imported** via `PuikResolver` (configured in
+  `vite.config.ts`). You don't need to import them manually — just use
+  `<PuikButton />` etc. directly in templates.
+- **Styling uses Tailwind v4.** In `src/style.css`, `@import "@prestashopcorp/puik-theme"`
+  must come *before* `@import "tailwindcss"` (the theme emits font `@import` rules
+  that must stay at the top of the file).
+- The production build prints one harmless `Invalid media query` warning coming
+  from `puik-theme` itself (upstream Puik bug, not this project).
 
-### Run Unit Tests with [Vitest](https://vitest.dev/)
+## IDE setup
 
-```sh
-npm run test:unit
-```
+[VSCode](https://code.visualstudio.com/) + [Vue - Official](https://marketplace.visualstudio.com/items?itemName=Vue.volar)
+(formerly Volar; disable Vetur). `vue-tsc` is used instead of `tsc` for type
+checking of `.vue` files.
 
-### Lint with [ESLint](https://eslint.org/)
+## Configuration reference
 
-```sh
-npm run lint
-```
+See the [Vite configuration reference](https://vite.dev/config/).


### PR DESCRIPTION
Documentation pass to make onboarding (human + agent) easier.

- **CLAUDE.md**: project overview, stack, commands, how Puik auto-import is wired,
  styling/gotchas (Tailwind v4, `@import` order, known upstream warning), git flow.
- **README.md**: replace the default Vite scaffolding README with accurate docs —
  the Puik purpose, the two routes, pnpm usage, and Tailwind v4 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)